### PR TITLE
Fix node label for page title with double quotes

### DIFF
--- a/sitemap.js
+++ b/sitemap.js
@@ -139,7 +139,7 @@ casper.run(function() {
     Object.keys(pages).forEach(function(key) {
         var nodeName = key.replace(/\W/g, '')
         if (nodeName) {
-            casper.echo("   " + nodeName + ' [label = "' + pages[key].title + '\\n' + pages[key].url.replace(site, '/') + '"];')
+            casper.echo("   " + nodeName + ' [label = "' + pages[key].title.replace(/"/g, '\\"') + '\\n' + pages[key].url.replace(site, '/') + '"];')
         }
     });
 


### PR DESCRIPTION
A little patch to escape double quotes in page titles.